### PR TITLE
Include config option to list stopped containers.

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "deviceName": "$hostname",
     "mac": "FF:FF:FF:FF:FF:FF",
     "port": 50045,
-    "pincode": "123-45-678"
+    "pincode": "123-45-678",
+    "listStoppedContainers":false
   }
 }

--- a/src/DockerKit.js
+++ b/src/DockerKit.js
@@ -11,6 +11,7 @@ const Events = require('events').EventEmitter;
 const emitter = new Events();
 exports.emitter = emitter;
 const SwitchAccessory = require('./SwitchAccessory');
+var ListAllContainers = false
 
 // Creates the Bridge. $hostname can be used as a variable for the Device's hostname
 const name = config.bridge.deviceName.replace('$hostname', os.hostname()).replace(/\./, ' ');
@@ -28,7 +29,7 @@ bridge.publish({
 // TODO Re Publish Devices every x minutes
 
 async function publishServices(all) {
-    const containerInfos = await docker.listContainers();
+    const containerInfos = await docker.listContainers({all: config.bridge.listStoppedContainers});
     for (let i in containerInfos) {
         if (!containerInfos.hasOwnProperty(i)) continue;
         const containerName = containerInfos[i].Names[0].replace('/', '');


### PR DESCRIPTION
Hi!

I noticed that the initial code was not listing my stopped containers, so I thought I could push a quick fix to correct that. Now you can set the setting "listStoppedContainers":false on config file to list stopped containers.

Default is false.